### PR TITLE
Add Controls index.md to content.yml 

### DIFF
--- a/doc/content.yml
+++ b/doc/content.yml
@@ -26,6 +26,7 @@ framework:
     - docs/content/documentation/systems/Variables/InitialCondition/index.md
     - docs/content/documentation/systems/Mesh/MortarInterfaces/index.md
     - docs/content/documentation/systems/Postprocessors/index.md
+    - docs/content/documentation/systems/Controls/index.md
     - docs/content/documentation/systems/Mesh/Partitioner/index.md
     - docs/content/documentation/systems/*/solid_mechanics/*
     - docs/content/documentation/systems/*/tensor_mechanics/*


### PR DESCRIPTION
Enables reference to `Controls` documentation root from within Mastodon documentation.