### PR TITLE
initial_stress refactor

### DIFF
--- a/examples/ex01/HYS_darendeli.i
+++ b/examples/ex01/HYS_darendeli.i
@@ -344,7 +344,7 @@
       number_of_points = 10
       poissons_ratio = '0.3'
       block = 0
-      initial_stress = '-4.204286 0 0  0 -4.204286 0  0 0 -9.810'
+      initial_soil_stress = '-4.204286 0 0  0 -4.204286 0  0 0 -9.810'
       density = '2'
       p_ref = '6.07286'
     [../]

--- a/examples/ex02/HYS_GQH.i
+++ b/examples/ex02/HYS_GQH.i
@@ -346,7 +346,7 @@
       number_of_points = 10
       poissons_ratio = '0.3'
       block = 0
-      initial_stress = '-4204.286 0 0  0 -4204.286 0  0 0 -9810'
+      initial_soil_stress = '-4204.286 0 0  0 -4204.286 0  0 0 -9810'
       density = '2000'
     [../]
   [../]

--- a/examples/ex03/shear_beam_Isoil_free_field.i
+++ b/examples/ex03/shear_beam_Isoil_free_field.i
@@ -198,7 +198,7 @@
        block = 0
        layer_variable = layer_id
        layer_ids = '0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19'
-       initial_stress = 'initial_xx 0 0 0 initial_xx 0 0 0 initial_zz'
+       initial_soil_stress = 'initial_xx 0 0 0 initial_xx 0 0 0 initial_zz'
        poissons_ratio = '0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3 0.3'
        soil_type = 2
        number_of_points = 100

--- a/examples/ex04/2BlockFriction_Isoilunit.i
+++ b/examples/ex04/2BlockFriction_Isoilunit.i
@@ -262,13 +262,18 @@
     type = ComputeIncrementalSmallStrain
     block = 1003
     displacements = 'disp_x disp_y disp_z'
+    eigenstrain_names = ini_stress
+  [../]
+  [./strain_from_initial_stress]
+    type = ComputeEigenstrainFromInitialStress
+    initial_stress = '0 0 0 0 0 0 0 0 initial_zztop'
+    eigenstrain_name = ini_stress
   [../]
   [./stress_top]
     #Computes the stress, using linear elasticity
     type = ComputeFiniteStrainElasticStress
     store_stress_old = true
     block = 1003
-    initial_stress = '0 0 0 0 0 0 0 0 initial_zztop'
   [../]
   [./den_top]
     type = GenericConstantMaterial
@@ -310,7 +315,7 @@
       data_file = 'backbone_curveunit.csv'
       poissons_ratio = '0.45'
       block = 1002
-      initial_stress = 'initial_ymid 0 0  0 initial_ymid 0  0 0 initial_zzmid'
+      initial_soil_stress = 'initial_ymid 0 0  0 initial_ymid 0  0 0 initial_zzmid'
       density = '2500'
       #initial_bulk_modulus = '7.83e10'
       #initial_shear_modulus = '2.7e10'

--- a/include/materials/ComputeISoilStress.h
+++ b/include/materials/ComputeISoilStress.h
@@ -136,6 +136,12 @@ protected:
 
   /// The position of the current layer id in the vector layer_ids.
   int _pos;
+
+  /// initial stress components
+  std::vector<Function *> _initial_soil_stress;
+
+  /// Whether initial stress was provided
+  const bool _initial_soil_stress_provided;
 };
 
 #endif // COMPUTEISOILSTRESS_H

--- a/src/actions/ISoilAction.C
+++ b/src/actions/ISoilAction.C
@@ -41,7 +41,7 @@ validParams<ISoilAction>()
       "Vector of layer ids that map one-to-one to the rest of the "
       "soil layer parameters provided as input.");
   params.addParam<std::vector<FunctionName>>(
-      "initial_stress",
+      "initial_soil_stress",
       "The function values for the initial stress distribution. 9 function "
       "names have to be provided corresponding to stress_xx, stress_xy, "
       "stress_xz, stress_yx, stress_yy, stress_yz, stress_zx, stress_zy, "
@@ -282,8 +282,8 @@ ISoilAction::act()
   params.set<std::vector<Real>>("p_ref") = p_ref;
   params.set<bool>("pressure_dependency") = getParam<bool>("pressure_dependency");
   params.set<bool>("store_stress_old") = true;
-  params.set<std::vector<FunctionName>>("initial_stress") =
-      getParam<std::vector<FunctionName>>("initial_stress");
+  params.set<std::vector<FunctionName>>("initial_soil_stress") =
+      getParam<std::vector<FunctionName>>("initial_soil_stress");
   params.set<bool>("wave_speed_calculation") = true;
   params.set<std::vector<unsigned int>>("layer_ids") = layer_ids;
   params.set<std::vector<VariableName>>("layer_variable") = layer_variable;

--- a/test/tests/materials/I_soil/HYS_GQH.i
+++ b/test/tests/materials/I_soil/HYS_GQH.i
@@ -346,7 +346,7 @@
       number_of_points = 10
       poissons_ratio = '0.3'
       block = 0
-      initial_stress = '-4204.286 0 0  0 -4204.286 0  0 0 -9810'
+      initial_soil_stress = '-4204.286 0 0  0 -4204.286 0  0 0 -9810'
       density = '2000'
     [../]
   [../]

--- a/test/tests/materials/I_soil/HYS_darendeli.i
+++ b/test/tests/materials/I_soil/HYS_darendeli.i
@@ -344,7 +344,7 @@
       number_of_points = 10
       poissons_ratio = '0.3'
       block = 0
-      initial_stress = '-4.204286 0 0  0 -4.204286 0  0 0 -9.810'
+      initial_soil_stress = '-4.204286 0 0  0 -4.204286 0  0 0 -9.810'
       density = '2'
       p_ref = '6.07286'
     [../]

--- a/test/tests/materials/I_soil/HYS_data_file.i
+++ b/test/tests/materials/I_soil/HYS_data_file.i
@@ -339,7 +339,7 @@
       data_file = 'stress_strain_darendelli.csv'
       poissons_ratio = '0.3'
       block = 0
-      initial_stress = '-4204.286 0 0  0 -4204.286 0  0 0 -9810'
+      initial_soil_stress = '-4204.286 0 0  0 -4204.286 0  0 0 -9810'
       density = '2000'
     [../]
   [../]

--- a/test/tests/materials/I_soil/HYS_pressure_dependent_stiffness.i
+++ b/test/tests/materials/I_soil/HYS_pressure_dependent_stiffness.i
@@ -342,7 +342,7 @@
       data_file = 'stress_strain20.csv'
       poissons_ratio = '0.3'
       block = 0
-      initial_stress = '-12613 0 0  0 -12613 0  0 0 -29430'
+      initial_soil_stress = '-12613 0 0  0 -12613 0  0 0 -29430'
       pressure_dependency = true
       b_exp = 0.0
       p_ref = 6072.86

--- a/test/tests/materials/I_soil/HYS_stiffness_and_strength_pressure_dependency.i
+++ b/test/tests/materials/I_soil/HYS_stiffness_and_strength_pressure_dependency.i
@@ -341,7 +341,7 @@
       data_file = 'stress_strain20.csv'
       poissons_ratio = '0.3'
       block = 0
-      initial_stress = '-12613 0 0  0 -12613 0  0 0 -29430'
+      initial_soil_stress = '-12613 0 0  0 -12613 0  0 0 -29430'
       pressure_dependency = true
       b_exp = 0.5
       p_ref = 6072.86


### PR DESCRIPTION
This is in preparation for deprecation of the initial_stress parameter in MOOSE's ComputeStressBase class.  In the future, MOOSE will default to using ComputeEigenstrainFromInitialStress instead of specifying the initial_stress parameter in ComputeStressBase, as this is more flexible when using time-varying elasticity tensors.  You can see an example of how to use this in ex04/2BlockFriction_Isoilunit.i

However, the ComputeISoilStress uses stress_old in its algorithm, and I'm not confident that I can successfully change the algorithm to use the old elastic strain, as we've done for MOOSE's TensorMechanics.  Therefore, I've created a new input parameter called "initial_soil_stress" that exactly replaces ComputeStressBase's "initial_stress".  Then ComputeISoilStress can happily use stress_old, and ComputeStressBase can deprecate its initial_stress.

The remainder of the changes are just the relevant changes in the Action and the test files.

Fixes #85