### PR TITLE
Change to calculation of eigenstrain from initial stress

### DIFF
--- a/examples/ex04/2BlockFriction_Isoilunit.i
+++ b/examples/ex04/2BlockFriction_Isoilunit.i
@@ -293,13 +293,19 @@
     type = ComputeIncrementalSmallStrain
     block = 1001
     displacements = 'disp_x disp_y disp_z'
+    eigenstrain_names = 'ini_stress_bot'
   [../]
   [./stress_bot]
     #Computes the stress, using linear elasticity
     type = ComputeFiniteStrainElasticStress
     store_stress_old = true
     block = 1001
+  [../]
+  [./strain_from_initial_stress_bot]
+    type = ComputeEigenstrainFromInitialStress
+    block = 1001
     initial_stress = 'initial_ybot 0 0 0 initial_ybot 0 0 0 initial_zzbot'
+    eigenstrain_name = ini_stress_bot
   [../]
   [./den_bot]
     type = GenericConstantMaterial


### PR DESCRIPTION
Changes over an input file to use `ComputeEigenstrainFromInitialStress` for all initial stress values.

@aeslaughter or @sveerara would you review this commit please? @WilkAndy needs this change for his removal of the `initial_stress` deprecated parameter in [idaholab/moose #11503](https://github.com/idaholab/moose/pull/11503)

Refs [idaholab/moose #10074](https://github.com/idaholab/moose/issues/10074)