### PR TITLE
Remove the include for bash_profile

### DIFF
--- a/doc/content/getting_started/macos.md
+++ b/doc/content/getting_started/macos.md
@@ -4,8 +4,6 @@
 
 !include /mac_pre_req.md
 
-!include /bash_profile.md
-
 !include /post_package_install.md
 
 !include getting_started/mastodon.md 

--- a/doc/content/getting_started/ubuntu.md
+++ b/doc/content/getting_started/ubuntu.md
@@ -4,8 +4,6 @@
 
 !include /ubuntu_pre_req.md
 
-!include /bash_profile.md
-
 !include /post_package_install.md
 
 !include getting_started/mastodon.md


### PR DESCRIPTION
bash_profile modification is no longer necessary.

This should be merged once/after https://github.com/idaholab/moose/pull/13339 is merged.


Closes #201