### PR TITLE
Changing home in config.yml to .org. Possible fix for search.

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -21,7 +21,7 @@ Extensions:
     MooseDocs.extensions.navigation:
         name: MASTODON
         repo: https://github.com/idaholab/mastodon
-        home: https://www.mooseframework.inl.gov/mastodon
+        home: https://www.mooseframework.org/mastodon
         menu:
             Getting Started:
                 MacOS (Mojave): getting_started/macos_mojave.md


### PR DESCRIPTION
Refs #156.

Currently, searching for something on the website through the search bar will result in a page load error. However, this seems to be fixed when I change the 'inl.gov' to '.org' in the address bar. I recently changed the home in config.yml to 'inl.gov', so that might have broken the search. I am reverting it to '.org' again. Somehow, this error doesn't show in the local build or the preview of the website in the PR. Pages from search load just fine in these cases. 