### PR TITLE
Site seismic risk updating example

### DIFF
--- a/examples/ex08/Master.i
+++ b/examples/ex08/Master.i
@@ -32,13 +32,13 @@
   [./motions]
     # Reads ground motion files for input
     type = GroundMotionReader
-    pattern = 'GM_00.csv'
+    pattern = 'GM_*.csv'
   [../]
   [./hazard]
     # Bins hazard curves into number_of_bins and scales ground motions
     type = HazardCurve
     filename = 'hazard.csv'
-    number_of_bins = 1
+    number_of_bins = 4
     ground_motions = motions
     reference_acceleration = 0.6
   [../]

--- a/examples/ex08/Master.i
+++ b/examples/ex08/Master.i
@@ -1,0 +1,85 @@
+# Test to demonstrate the Seismic Probabilistic Risk Assessment (SPRA)
+# infrastructure in MASTODON. This test involves three input files:
+#
+# 1. master.i - The Master file that bins the hazard curve and scales ground
+# motions for each bin for use in probabilistic simulations.
+#
+# 2. sub.i - The file that obtains the scaled ground motions from master.i and
+# transfers these ground motions as inputs to the finite-element model and also
+# contains the parameters for probabilistic simulation. This file acts as the
+# sub file for master.i and master file for subsub.i.
+#
+# 3. subsub.i - The file that contains the finite-element model.
+
+[Mesh]
+  # dummy mesh
+  type = GeneratedMesh
+  dim = 3
+[]
+
+[Variables]
+  # dummy variables
+  [./u]
+  [../]
+[]
+
+[Problem]
+  solve = false
+  kernel_coverage_check = false
+[]
+
+[UserObjects]
+  [./motions]
+    # Reads ground motion files for input
+    type = GroundMotionReader
+    pattern = 'GM_00.csv'
+  [../]
+  [./hazard]
+    # Bins hazard curves into number_of_bins and scales ground motions
+    type = HazardCurve
+    filename = 'hazard.csv'
+    number_of_bins = 1
+    ground_motions = motions
+    reference_acceleration = 0.6
+  [../]
+[]
+
+[MultiApps]
+  [./run_hazard]
+    type = HazardCurveMultiApp
+    hazard = hazard
+    input_files = 'sub_NPP_Stick.i'
+    execute_on = 'initial timestep_end'
+  [../]
+[]
+
+[Transfers]
+  [./transfer_x]
+    # Transfers scaled ground motions to multiapp
+    type = HazardCurveTransfer
+    multi_app = run_hazard
+    function = accel_x # Function in sub.i that receives the scaled ground motions
+    component = x # component that is being transferred
+  [../]
+[]
+
+[Executioner]
+  # governs the PRA execution in case of conflict with sub.i or subsub.i
+  type = Transient
+  solve_type = 'PJFNK'
+  petsc_options = '-snes_ksp_ew'
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
+  petsc_options_value = '201                hypre    boomeramg      4'
+  end_time = 2.0
+  dt = 0.1
+  dtmin = 0.01
+  nl_abs_tol = 1e-3
+    nl_rel_tol = 1e-03
+  l_tol = 1e-3
+  l_max_its = 20
+  timestep_tolerance = 1e-3
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/examples/ex08/sub_NPP_Stick.i
+++ b/examples/ex08/sub_NPP_Stick.i
@@ -1,0 +1,145 @@
+# Test to demonstrate the Seismic Probabilistic Risk Assessment (SPRA)
+# infrastructure in MASTODON. This test involves three input files:
+#
+# 1. master.i - The Master file that bins the hazard curve and scales ground
+# motions for each bin for use in probabilistic simulations.
+#
+# 2. sub.i - The file that obtains the scaled ground motions from master.i and
+# transfers these ground motions as inputs to the finite-element model and also
+# contains the parameters for probabilistic simulation. This file acts as the
+# sub file for master.i and master file for subsub.i.
+#
+# 3. subsub.i - The file that contains the finite-element model.
+
+[Mesh]
+  type = FileMesh
+  file = foundbeam_noded.e
+[]
+
+[Variables]
+  [./disp_x]
+  [../]
+  [./disp_y]
+  [../]
+  [./disp_z]
+  [../]
+  [./rot_x]
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16'
+  [../]
+  [./rot_y]
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16'
+  [../]
+  [./rot_z]
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16'
+  [../]
+[]
+
+[Problem]
+  solve = false
+  kernel_coverage_check = false
+[]
+
+[Distributions]
+  [./uniform_zeta]
+    type = BoostLognormalDistribution
+    location = -7.5167
+    scale = 0.35
+  [../]
+  [./uniform_eta]
+    type = BoostLognormalDistribution
+    location = 1.1837
+    scale = 0.35
+  [../]
+ [./uniform_E1]
+   type = UniformDistribution
+   lower_bound = 1.9e5
+   upper_bound = 9.9e5
+ [../]
+ [./uniform_E2]
+   type = UniformDistribution
+   lower_bound = 1.9e5
+   upper_bound = 9.9e5
+ [../]
+ [./uniform_E3]
+   type = UniformDistribution
+   lower_bound = 5e7
+   upper_bound = 5e8
+ [../]
+[]
+
+[Samplers]
+  [./sample]
+    type = MonteCarloSampler
+    n_samples = 2
+    distributions = 'uniform_zeta uniform_eta uniform_E1 uniform_E2 uniform_E3'
+    execute_on = INITIAL # create random numbers on initial and use them for each timestep
+  [../]
+[]
+
+[MultiApps]
+  [./sub]
+    # creates sub files for each monte carlo sample and each scaled ground motion
+    # Total number of simulations = number_of_bins * num_gms * n_samples
+    type = SamplerTransientMultiApp
+    input_files = 'sub_sub_NPP_Stick.i'
+    sampler = sample
+    execute_on = TIMESTEP_BEGIN
+  [../]
+[]
+
+[Transfers]
+  [./sub]
+    # transfers monte carlo samples to multiapp
+    type = SamplerTransfer
+    multi_app = sub
+    parameters = 'Materials/material_zeta/prop_values Materials/material_eta/prop_values AuxKernels/youngs_modulus1/value AuxKernels/youngs_modulus2/value AuxKernels/youngs_modulus3/value'
+    to_control = 'stochastic'
+    execute_on = INITIAL
+    check_multiapp_execute_on = false
+  [../]
+  [./transfer]
+    # transfers scaled ground motions to multiapp
+    type = PiecewiseFunctionTransfer
+    multi_app = sub
+    direction = to_multiapp
+    to_function = accel_x # name of function in subsub.i which uses the scaled ground motions
+    from_function = accel_x # name of the function in sub.i, which receives the scaled ground motions
+  [../]
+[]
+
+[Functions]
+  [./accel_x]
+    type = PiecewiseLinear
+    # Piecewiselinear function that receiving scaled GMs from master.i. Input here is dummy.
+    x = '32 34'
+    y = '0 0'
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'PJFNK'
+  petsc_options = '-snes_ksp_ew'
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
+  petsc_options_value = '201                hypre    boomeramg      4'
+  end_time = 2.0
+  dt = 0.1
+  dtmin = 0.01
+  nl_abs_tol = 1e-3
+    nl_rel_tol = 1e-03
+  l_tol = 1e-3
+  l_max_its = 20
+  timestep_tolerance = 1e-3
+[]
+
+[VectorPostprocessors]
+  [./data]
+    type = SamplerData
+    sampler = sample
+    execute_on = 'LINEAR'
+  [../]
+[]
+
+[Outputs]
+  csv = true
+[]

--- a/examples/ex08/sub_sub_NPP_Stick.i
+++ b/examples/ex08/sub_sub_NPP_Stick.i
@@ -1,0 +1,626 @@
+[Mesh]
+  type = FileMesh
+  file = foundbeam_noded.e
+[]
+
+[Variables]
+  [./disp_x]
+  [../]
+  [./disp_y]
+  [../]
+  [./disp_z]
+  [../]
+  [./rot_x]
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16'
+  [../]
+  [./rot_y]
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16'
+  [../]
+  [./rot_z]
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16'
+  [../]
+[]
+
+[AuxVariables]
+  [./vel_x]
+  [../]
+  [./vel_y]
+  [../]
+  [./vel_z]
+  [../]
+  [./accel_x]
+  [../]
+  [./accel_y]
+  [../]
+  [./accel_z]
+  [../]
+  [./rot_vel_x]
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16'
+  [../]
+  [./rot_vel_y]
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16'
+  [../]
+  [./rot_vel_z]
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16'
+  [../]
+  [./rot_accel_x]
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16'
+  [../]
+  [./rot_accel_y]
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16'
+  [../]
+  [./rot_accel_z]
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16'
+  [../]
+  [./youngs_modulus1]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./youngs_modulus2]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./youngs_modulus3]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[Kernels]
+  [./DynamicTensorMechanics]
+    displacements = 'disp_x disp_y disp_z'
+    zeta = 'zeta_rayleigh' # stiffness proportional damping
+    block = 15
+  [../]
+  [./inertia_x]
+    type = InertialForce
+    variable = disp_x
+    velocity = vel_x
+    acceleration = accel_x
+    beta = 0.25
+    gamma = 0.5
+    eta = 'eta_rayleigh' # Mass proportional Rayleigh damping
+    block = 15
+  [../]
+  [./inertia_y]
+    type = InertialForce
+    variable = disp_y
+    velocity = vel_y
+    acceleration = accel_y
+    beta = 0.25
+    gamma = 0.5
+    eta = 'eta_rayleigh' # Mass proportional Rayleigh damping
+    block = 15
+  [../]
+  [./inertia_z]
+    type = InertialForce
+    variable = disp_z
+    velocity = vel_z
+    acceleration = accel_z
+    beta = 0.25
+    gamma = 0.5
+    eta = 'eta_rayleigh' # Mass proportional Rayleigh damping
+    block = 15
+  [../]
+[]
+
+[AuxKernels]
+  [./accel_x]
+    type = NewmarkAccelAux
+    variable = accel_x
+    displacement = disp_x
+    velocity = vel_x
+    beta = 0.25
+    execute_on = 'timestep_end'
+  [../]
+  [./vel_x]
+    type = NewmarkVelAux
+    variable = vel_x
+    acceleration = accel_x
+    gamma = 0.5
+    execute_on = 'timestep_end'
+  [../]
+  [./accel_y]
+    type = NewmarkAccelAux
+    variable = accel_y
+    displacement = disp_y
+    velocity = vel_y
+    beta = 0.25
+    execute_on = 'timestep_end'
+  [../]
+  [./vel_y]
+    type = NewmarkVelAux
+    variable = vel_y
+    acceleration = accel_y
+    gamma = 0.5
+    execute_on = 'timestep_end'
+  [../]
+  [./accel_z]
+    type = NewmarkAccelAux
+    variable = accel_z
+    displacement = disp_z
+    velocity = vel_z
+    beta = 0.25
+    execute_on = 'timestep_end'
+  [../]
+  [./vel_z]
+    type = NewmarkVelAux
+    variable = vel_z
+    acceleration = accel_z
+    gamma = 0.5
+    execute_on = 'timestep_end'
+  [../]
+  [./youngs_modulus1]
+    type = ConstantAux
+    variable = youngs_modulus1
+    value = 6.9e5
+  [../]
+  [./youngs_modulus2]
+    type = ConstantAux
+    variable = youngs_modulus2
+    value = 3.45e5
+  [../]
+  [./youngs_modulus3]
+    type = ConstantAux
+    variable = youngs_modulus3
+    value = 9e7
+  [../]
+[]
+
+[Modules/TensorMechanics/LineElementMaster]
+#    add_variables = true
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+
+    # dynamic simulation using consistent mass/inertia matrix
+    dynamic_nodal_translational_inertia = true
+
+    velocities = 'vel_x vel_y vel_z'
+    accelerations = 'accel_x accel_y accel_z'
+    rotational_velocities = 'rot_vel_x rot_vel_y rot_vel_z'
+    rotational_accelerations = 'rot_accel_x rot_accel_y rot_accel_z'
+
+    beta = 0.25 # Newmark time integration parameter
+    gamma = 0.5 # Newmark time integration parameter
+
+    # parameters for 5% Rayleigh damping
+    zeta = 0.0005438894818 # stiffness proportional damping
+    eta = 3.26645357034 # Mass proportional Rayleigh damping
+  [./block_1]
+    block = 1
+    area = 1400
+    Iy = 2.8e6
+    Iz = 2.8e6
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 142.860001
+    boundary = 1 # vertex 2
+  [../]
+  [./block_2]
+    block = 2
+    area = 1400
+    Iy = 2.8e6
+    Iz = 2.8e6
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 130.429993
+    boundary = 2 # vertex 4, 6, 8, 10, 12
+  [../]
+  [./block_3]
+    block = 3
+    area = 1400
+    Iy = 2.8e6
+    Iz = 2.8e6
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 143.169998
+    boundary = 3 # vertex 12
+  [../]
+  [./block_4]
+    block = 4
+    area = 990
+    Iy = 1.9e6
+    Iz = 1.9e6
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 93.79000092
+    boundary = 4 # vertex 14
+  [../]
+  [./block_5]
+    block = 5
+    area = 990
+    Iy = 1.5e6
+    Iz = 1.5e6
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 76.70999908
+    boundary = 5 # vertex 16
+  [../]
+  [./block_6]
+    block = 6
+    area = 990
+    Iy = 8e5
+    Iz = 8e5
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 65.83999634
+    boundary = 6 # vertex 18
+  [../]
+  [./block_7]
+    block = 7
+    area = 990
+    Iy = 2e5
+    Iz = 2e5
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 5.90000010
+    boundary = 7 # vertex 20
+  [../]
+  # right
+  [./block_8]
+    block = 8
+    area = 2000
+    Iy = 1.1e6
+    Iz = 1.1e6
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 86.95999908
+    boundary = 8 # vertex 22
+  [../]
+  [./block_9]
+    block = 9
+    area = 2560
+    Iy = 1.2e6
+    Iz = 1.2e6
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 77.94999695
+    boundary = 9 # vertex 24
+  [../]
+  [./block_10]
+    block = 10
+    area = 2210
+    Iy = 1.2e6
+    Iz = 1.2e6
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 195.339996
+    boundary = 10 # vertex 26
+  [../]
+  [./block_11]
+    block = 11
+    area = 1960
+    Iy = 1.3e6
+    Iz = 1.3e6
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 116.769997
+    boundary = 11 # vertex 28
+  [../]
+  [./block_12]
+    block = 12
+    area = 1740
+    Iy = 9e5
+    Iz = 9e5
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 265.220001
+    boundary = 12 # vertex 30
+  [../]
+  [./block_13]
+    block = 13
+    area = 780
+    Iy = 2e5
+    Iz = 2e5
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 37.88999939
+    boundary = 13 # vertex 32
+  [../]
+  [./block_14]
+    block = 14
+    area = 190
+    Iy = 4000.0
+    Iz = 4000.0
+    y_orientation = '0.0 1.0 0.0'
+
+    nodal_mass = 25.46999931
+    boundary = 14 # vertex 34
+  [../]
+  [./block_16]
+    block = 16
+    area = 2000
+    Iy = 2.8e6
+    Iz = 2.8e6
+    y_orientation = '0.0 0.0 1.0'
+    dynamic_nodal_translational_inertia = false
+  [../]
+[]
+
+[Materials]
+  [./elasticity_beam_outer_1]
+    type = ComputeElasticityBeam
+    youngs_modulus = youngs_modulus1
+    poissons_ratio = 0.278
+    shear_coefficient = 0.5
+    block = '1 2 3'
+  [../]
+  [./elasticity_beam_outer_2]
+    type = ComputeElasticityBeam
+    youngs_modulus = youngs_modulus1
+    poissons_ratio = 0.278
+    shear_coefficient = 0.505
+    block = '4 5 6 7'
+  [../]
+  [./elasticity_beam_inner_1]
+    type = ComputeElasticityBeam
+    youngs_modulus = youngs_modulus2
+    poissons_ratio = 0.278
+    shear_coefficient = 0.66
+    block = '8'
+  [../]
+  [./elasticity_beam_inner_2]
+     type = ComputeElasticityBeam
+     youngs_modulus = youngs_modulus2
+     poissons_ratio = 0.278
+     shear_coefficient = 0.609375
+     block = '9'
+  [../]
+  [./elasticity_beam_inner_3]
+    type = ComputeElasticityBeam
+    youngs_modulus = youngs_modulus2
+    poissons_ratio = 0.278
+    shear_coefficient = 0.6606
+    block = '10'
+  [../]
+  [./elasticity_beam_inner_4]
+    type = ComputeElasticityBeam
+    youngs_modulus = youngs_modulus2
+    poissons_ratio = 0.278
+    shear_coefficient = 0.372
+    block = '11'
+  [../]
+  [./elasticity_beam_inner_5]
+    type = ComputeElasticityBeam
+    youngs_modulus = youngs_modulus2
+    poissons_ratio = 0.278
+    shear_coefficient = 0.345
+    block = '12'
+  [../]
+  [./elasticity_beam_inner_6]
+    type = ComputeElasticityBeam
+    youngs_modulus = youngs_modulus2
+    poissons_ratio = 0.278
+    shear_coefficient = 0.462
+    block = '13'
+  [../]
+  [./elasticity_beam_inner_7]
+    type = ComputeElasticityBeam
+    youngs_modulus = youngs_modulus2
+    poissons_ratio = 0.278
+    shear_coefficient = 0.368
+    block = '14'
+  [../]
+  [./elasticity_beam_foundation]
+    type = ComputeIsotropicElasticityTensor
+    youngs_modulus = 9e7
+    poissons_ratio = 0
+    block = '15'
+  [../]
+  [./foundation_connecting_beam]
+    type = ComputeElasticityBeam
+    youngs_modulus = youngs_modulus3
+    poissons_ratio = 0
+    shear_coefficient = 0.833
+    block = '16'
+  [../]
+  [./stress_beam]
+    type = ComputeBeamResultants
+    block = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 16'
+  [../]
+  [./stress_beam2]
+    type = ComputeFiniteStrainElasticStress
+    block = '15'
+  [../]
+  [./strain_15]
+    type = ComputeFiniteStrain
+    block = '15'
+    displacements = 'disp_x disp_y disp_z'
+  [../]
+  [./density]
+    type = GenericConstantMaterial
+    block = '15 16'
+    prop_names = density
+    prop_values =  0.115
+  [../]
+  [./material_zeta]
+    type = GenericConstantMaterial
+    # block = '15'
+    prop_names = 'zeta_rayleigh'
+    prop_values = '0.0005438894818'
+  [../]
+  [./material_eta]
+    type = GenericConstantMaterial
+    # block = '15'
+    prop_names = 'eta_rayleigh'
+    prop_values = '3.26645357034'
+  [../]
+[]
+
+[BCs]
+  [./disp_x]
+    type = PresetAcceleration
+    variable = disp_x
+    velocity = vel_x
+    acceleration = accel_x
+    beta = 0.25
+    function = accel_x
+    boundary = '100'
+  [../]
+  [./disp_y]
+    type = PresetBC
+    variable = disp_y
+    boundary = '100'
+    value = 0.0
+  [../]
+  [./disp_z]
+    type = PresetBC
+    variable = disp_z
+    boundary = '100'
+    value = 0.0
+  [../]
+  [./rot_x]
+    type = DirichletBC
+    boundary = '1002'
+    variable = rot_x
+    value = 0.0
+  [../]
+  [./rot_y]
+    type = DirichletBC
+    boundary = '1002'
+    variable = rot_y
+    value = 0.0
+  [../]
+  [./rot_z]
+    type = DirichletBC
+    boundary = '1002'
+    variable = rot_z
+    value = 0.0
+  [../]
+[]
+
+[Functions]
+  [./accel_x]
+    type = PiecewiseLinear
+    data_file = 'GM_00.csv'
+    format = columns
+    scale_factor = 1.0
+    xy_in_file_only = false
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'PJFNK'
+  petsc_options = '-snes_ksp_ew'
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
+  petsc_options_value = '201                hypre    boomeramg      4'
+  end_time = 2.0
+  dt = 0.1
+  dtmin = 0.01
+  nl_abs_tol = 1e-3
+    nl_rel_tol = 1e-03
+  l_tol = 1e-3
+  l_max_its = 20
+  timestep_tolerance = 1e-3
+[]
+
+[Controls]
+  [./stochastic]
+    type = SamplerReceiver
+  [../]
+[]
+
+[Postprocessors]
+    [./accel_x_11]
+    type = PointValue
+    variable = accel_x
+    point = '0.0 0.0 217.0'
+  [../]
+  [./accel_y_11]
+    type = PointValue
+    variable = accel_y
+    point = '0.0 0.0 217.0'
+  [../]
+  [./accel_z_11]
+    type = PointValue
+    variable = accel_z
+    point = '0.0 0.0 217.0'
+  [../]
+  [./accel_x_14]
+    type = NodalVariableValue
+    variable = accel_x
+    nodeid = 238
+  [../]
+  [./accel_y_14]
+    type = NodalVariableValue
+    variable = accel_y
+    nodeid = 238
+  [../]
+  [./accel_z_14]
+    type = NodalVariableValue
+    variable = accel_z
+    nodeid = 238
+  [../]
+  [./accel_x_17]
+    type = NodalVariableValue
+    variable = accel_x
+    nodeid = 278
+  [../]
+  [./accel_y_17]
+    type = NodalVariableValue
+    variable = accel_y
+    nodeid = 278
+  [../]
+  [./accel_z_17]
+    type = NodalVariableValue
+    variable = accel_z
+    nodeid = 278
+  [../]
+  [./accel_x_18]
+    type = NodalVariableValue
+    variable = accel_x
+    nodeid = 311
+  [../]
+  [./accel_y_18]
+    type = NodalVariableValue
+    variable = accel_y
+    nodeid = 311
+  [../]
+  [./accel_z_18]
+    type = NodalVariableValue
+    variable = accel_z
+    nodeid = 311
+  [../]
+[]
+
+[VectorPostprocessors]
+  [./accel_hist]
+    type = ResponseHistoryBuilder
+    variables = 'accel_x accel_y accel_z'
+    nodes = '1 238 209 278 311 217'
+  [../]
+  [./accel_spec]
+    type = ResponseSpectraCalculator
+    vectorpostprocessor = accel_hist
+    regularize_dt = 0.005
+    outputs = out
+  [../]
+[]
+
+[Outputs]
+[./out]
+  type = CSV
+[../]
+[]
+
+# [Outputs]
+#   [./out]
+#     type = CSV
+#     execute_on = 'final'
+#     file_base = matfoundation_response
+#   [../]
+#   exodus = true
+#   [./console]
+#     type = Console
+#     max_rows = 1
+#   [../]
+#
+# []

--- a/examples/ex08/sub_sub_Timoshenko.i
+++ b/examples/ex08/sub_sub_Timoshenko.i
@@ -1,0 +1,300 @@
+# Test for small strain Timoshenko beam vibration in y direction
+
+# An impulse load is applied at the end of a cantilever beam of length 4m.
+# The properties of the cantilever beam are as follows:
+# Young's modulus (E) = 2e4
+# Shear modulus (G) = 1e4
+# Shear coefficient (k) = 1.0
+# Cross-section area (A) = 1.0
+# Iy = 1.0 = Iz
+# Length (L)= 4 m
+# density (rho) = 1.0
+
+# For this beam, the dimensionless parameter alpha = kAGL^2/EI = 8
+# Therefore, the beam behaves like a Timoshenko beam.
+
+# The FEM solution for this beam with 100 elements give first natural period of 0.2731s with a time step of 0.005.
+# The acceleration, velocity and displacement time histories obtained from MOOSE matches with those obtained from ABAQUS.
+
+# Values from the first few time steps are as follows:
+# time    disp_y                vel_y                 accel_y
+# 0.0     0.0                   0.0                   0.0
+# 0.005   2.5473249455812e-05   0.010189299782325     4.0757199129299
+# 0.01    5.3012872677486e-05   0.00082654950634483  -7.8208200233219
+# 0.015   5.8611622914354e-05   0.0014129505884026    8.055380456145
+# 0.02    6.766113649781e-05    0.0022068548449798   -7.7378187535141
+# 0.025   7.8981810558437e-05   0.0023214147792709    7.7836427272305
+
+# Note that the theoretical first frequency of the beam using Euler-Bernoulli theory is:
+# f1 = 1/(2 pi) * (3.5156/L^2) * sqrt(EI/rho) = 4.9455
+
+# This implies that the corresponding time period of this beam (under Euler-Bernoulli assumption) is 0.2022s.
+
+# This shows that Euler-Bernoulli beam theory under-predicts the time period of a thick beam. In other words, the Euler-Bernoulli beam theory predicts a more compliant beam than reality for a thick beam.
+
+[Mesh]
+  type = GeneratedMesh
+  dim = 1
+  nx = 10
+  xmin = 0.0
+  xmax = 4.0
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[AuxVariables]
+  [./youngs_modulus1]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./poisson_ratio1]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./shear_coefficient1]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[BCs]
+  [./fixx1]
+    type = DirichletBC
+    variable = disp_x
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixy1]
+    type = DirichletBC
+    variable = disp_y
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixz1]
+    type = DirichletBC
+    variable = disp_z
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixr1]
+    type = DirichletBC
+    variable = rot_x
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixr2]
+    type = DirichletBC
+    variable = rot_y
+    boundary = left
+    value = 0.0
+  [../]
+  [./fixr3]
+    type = DirichletBC
+    variable = rot_z
+    boundary = left
+    value = 0.0
+  [../]
+  [./app_acc]
+    type = PresetAcceleration
+    variable = disp_y
+    velocity = vel_y
+    acceleration = accel_y
+    beta = 0.25
+    function = accel_y
+    boundary = right
+  [../]
+[]
+
+[NodalKernels]
+  [./force_y2]
+    type = UserForcingFunctionNodalKernel
+    variable = disp_y
+    boundary = right
+    function = force
+  [../]
+[]
+
+[AuxKernels]
+  [./accel_x]
+    type = NewmarkAccelAux
+    variable = accel_x
+    displacement = disp_x
+    velocity = vel_x
+    beta = 0.25
+    execute_on = 'timestep_end'
+  [../]
+  [./vel_x]
+    type = NewmarkVelAux
+    variable = vel_x
+    acceleration = accel_x
+    gamma = 0.5
+    execute_on = 'timestep_end'
+  [../]
+  [./accel_y]
+    type = NewmarkAccelAux
+    variable = accel_y
+    displacement = disp_y
+    velocity = vel_y
+    beta = 0.25
+    execute_on = 'timestep_end'
+  [../]
+  [./vel_y]
+    type = NewmarkVelAux
+    variable = vel_y
+    acceleration = accel_y
+    gamma = 0.5
+    execute_on = 'timestep_end'
+  [../]
+  [./accel_z]
+    type = NewmarkAccelAux
+    variable = accel_z
+    displacement = disp_z
+    velocity = vel_z
+    beta = 0.25
+    execute_on = 'timestep_end'
+  [../]
+  [./vel_z]
+    type = NewmarkVelAux
+    variable = vel_z
+    acceleration = accel_z
+    gamma = 0.5
+    execute_on = 'timestep_end'
+  [../]
+  [./youngs_modulus1]
+    type = ConstantAux
+    variable = youngs_modulus1
+    value = 1e04
+  [../]
+  [./poisson_ratio1]
+    type = ConstantAux
+    variable = poisson_ratio1
+    value = 0.3
+  [../]
+  [./shear_coefficient1]
+    type = ConstantAux
+    variable = shear_coefficient1
+    value = 1
+  [../]
+[]
+
+[Functions]
+  # [./force]
+  #   type = PiecewiseLinear
+  #   x = '0.0 0.1 0.2 10.0'
+  #   y = '0.0 1e-2  0.0  0.0'
+  # [../]
+  [./force]
+    type = ConstantFunction
+    value = 0
+  [../]
+  [./accel_y]
+    type = PiecewiseLinear
+    data_file = 'GM_00.csv'
+    format = columns
+    scale_factor = 1.0
+    xy_in_file_only = false
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'PJFNK'
+  petsc_options = '-snes_ksp_ew'
+  petsc_options_iname = '-ksp_gmres_restart -pc_type -pc_hypre_type -pc_hypre_boomeramg_max_iter'
+  petsc_options_value = '201                hypre    boomeramg      4'
+  end_time = 48.0
+  dt = 0.01
+  dtmin = 0.01
+  nl_abs_tol = 1e-3
+    nl_rel_tol = 1e-3
+  l_tol = 1e-3
+  l_max_its = 20
+  timestep_tolerance = 1e-3
+[]
+
+[Modules/TensorMechanics/LineElementMaster]
+  [./all]
+    add_variables = true
+    displacements = 'disp_x disp_y disp_z'
+    rotations = 'rot_x rot_y rot_z'
+
+    # Geometry parameters
+    area = 0.01
+    Iy = 1e-4
+    Iz = 1e-4
+    y_orientation = '0.0 1.0 0.0'
+
+    # dynamic simulation using consistent mass/inertia matrix
+    dynamic_nodal_translational_inertia = true
+    nodal_mass = 18.99772
+
+    dynamic_nodal_rotational_inertia = true
+    nodal_Ixx = 2e-1
+    nodal_Iyy = 1e-1
+    nodal_Izz = 1e-1
+
+    velocities = 'vel_x vel_y vel_z'
+    accelerations = 'accel_x accel_y accel_z'
+    rotational_velocities = 'rot_vel_x rot_vel_y rot_vel_z'
+    rotational_accelerations = 'rot_accel_x rot_accel_y rot_accel_z'
+
+    beta = 0.25 # Newmark time integration parameter
+    gamma = 0.5 # Newmark time integration parameter
+
+    boundary = right # Node set where nodal mass and nodal inertia are applied
+
+    # parameters for 5% Rayleigh damping
+    zeta = zeta1 # stiffness proportional damping
+    eta = eta1 # Mass proportional Rayleigh damping
+  [../]
+[]
+
+[Materials]
+  [./elasticity]
+    type = ComputeElasticityBeam
+    youngs_modulus = youngs_modulus1
+    poissons_ratio = poisson_ratio1
+    shear_coefficient = shear_coefficient1
+  [../]
+  [./stress]
+    type = ComputeBeamResultants
+  [../]
+[]
+
+[Controls]
+  [./stochastic]
+    type = SamplerReceiver
+  [../]
+[]
+
+[Postprocessors]
+  [./disp_y]
+    type = PointValue
+    point = '4.0 0.0 0.0'
+    variable = disp_y
+  [../]
+  [./vel_y]
+    type = PointValue
+    point = '4.0 0.0 0.0'
+    variable = vel_y
+  [../]
+  [./accel_y]
+    type = PointValue
+    point = '4.0 0.0 0.0'
+    variable = accel_y
+  [../]
+[]
+
+[Outputs]
+  file_base = 'Outputs1'
+  exodus = true
+  csv = true
+
+  perf_graph = true
+[]


### PR DESCRIPTION
We are evaluating the seismic risk of collapse of a nuclear facility using old and new seismic hazard curves. Subject to the availability of time, we are also evaluating the impact of the updated fragility function parameters on the seismic risk using a Bayesian approach. Following are the sections in the documentation of this example:

1. Introduction

2. Methodology for risk updating in light of new seismic hazard
 2.1 Seismic hazard analysis and re-analysis
 2.2 Seismic fragility evaluation
 2.3 Event and fault trees for risk evaluation

3. Results
 3.1 Seismic hazard
 3.2 Fragility analysis
 3.3 Risk analysis

4. Bayesian procedure for risk updating in light of new fragility data (time permitting)

5. Conclusions and future recommendations