### PR TITLE
Mastodon fix corresponding to Moose PR #258

### DIFF
--- a/src/transfers/HazardCurveTransfer.C
+++ b/src/transfers/HazardCurveTransfer.C
@@ -1,7 +1,7 @@
 // MOOSE includes
 #include "FEProblemBase.h"
 #include "MultiApp.h"
-#include "Piecewise.h"
+#include "PiecewiseBase.h"
 #include "Conversion.h"
 
 // MASTODON includes


### PR DESCRIPTION
Fix for Mastodon. Merge after Moose PR 14221 gets merged.