### PR TITLE
removed boost distribution calls.  Call static lognormal distribution functions

### DIFF
--- a/include/utils/MastodonUtils.h
+++ b/include/utils/MastodonUtils.h
@@ -17,8 +17,6 @@
 
 // MOOSE includes
 #include "GeneralVectorPostprocessor.h"
-// Other includes
-#include "BoostDistribution.h"
 
 // Forward Declarations
 namespace MastodonUtils
@@ -99,37 +97,10 @@ Real lognormalStandardDeviation(const std::vector<Real> & vector);
  * Function to calculate the probability that one random variable is greater
  * than another random variable
  */
-Real greaterProbability(Distribution & demand_distribution, Distribution & capacity_distribution);
-
-// Function declarations that require external Boost
-#ifdef LIBMESH_HAVE_EXTERNAL_BOOST
-/**
- * Function template to calculate the probability that one random variable is greater
- * than another random variable for Boost distribution
- */
-template <typename T>
-Real
-greaterProbability(T & demand_distribution, T & capacity_distribution)
-{
-  Real min_demand =
-      boost::math::quantile(demand_distribution, 0.001); //~ -3 sigma for normal distributions
-  Real max_demand =
-      boost::math::quantile(demand_distribution, 0.999); //~ +3 sigma for normal distributions
-  Real prob = 0.0;
-  Real param = min_demand;
-  Real p_1, p_2;
-  Real delta = boost::math::median(demand_distribution) / 1000;
-  while (param < max_demand)
-  {
-    p_1 = boost::math::pdf(demand_distribution, param) *
-          boost::math::cdf(capacity_distribution, param);
-    p_2 = boost::math::pdf(demand_distribution, param + delta) *
-          boost::math::cdf(capacity_distribution, param + delta);
-    prob += delta * (p_1 + p_2) / 2;
-    param += delta;
-  }
-  return prob;
-}
+Real greaterProbability(Real demand_median,
+                        Real demand_scale,
+                        Real capacity_median,
+                        Real capacity_scale);
 
 /**
  * Function to calculate the loglikelihood (for MLE fiting) given the data
@@ -156,8 +127,6 @@ std::vector<Real> maximizeLogLikelihood(const std::vector<Real> & im,
                                         const Real gamma,
                                         const int num_rnd,
                                         const int seed);
-
-#endif // LIBMESH_HAVE_EXTERNAL_BOOST
 
 /**
  * This function zeropads the number n with zeros in the beginning and makes n

--- a/test/tests/pra/sub.i
+++ b/test/tests/pra/sub.i
@@ -30,7 +30,7 @@
 
 [Distributions]
   [./lognormal_density]
-    type = BoostLognormalDistribution
+    type = Lognormal
     location = 0 # log(1.0); median = 1.0
     scale = 1.3
   [../]

--- a/test/tests/pra/tests
+++ b/test/tests/pra/tests
@@ -7,7 +7,6 @@
   [./pra]
     type = CSVDiff
     input = master.i
-    boost = true
     allow_warnings = true # temporary to allow new API in MOOSE
     csvdiff = "master_out_run_hazard0_sub0.csv
                master_out_run_hazard0_sub1.csv

--- a/test/tests/vectorpostprocessors/fragility/tests
+++ b/test/tests/vectorpostprocessors/fragility/tests
@@ -7,16 +7,12 @@
     type = CSVDiff
     input = fragility_brute_force.i
     csvdiff = fragility_brute_force_out_fragility_pump_0002.csv
-    boost = true
-
     requirement = "The Fragility vectorpostprocessor shall accurately evaluate the median demands, beta, and the conditional probability of failure of the SSC at each intensity, and the median and beta of the enhanced fragility fit for the SSC using a brute force approach."
   [../]
   [./fragility_sgd]
     type = CSVDiff
     input = fragility_sgd.i
     csvdiff = fragility_sgd_out_fragility_pump_0002.csv
-    boost = true
-
     requirement = "The Fragility vectorpostprocessor shall accurately evaluate the median demands, beta, and the conditional probability of failure of the SSC at each intensity, and the median and beta of the enhanced fragility fit for the SSC using the stochastic gradient descent algorithm."
   [../]
 []

--- a/unit/src/TestMastodonUtils.C
+++ b/unit/src/TestMastodonUtils.C
@@ -307,8 +307,7 @@ TEST(MastodonUtils, calcLogLikelihood)
   // Outputs for testing
   Real loglikelihood = MastodonUtils::calcLogLikelihood(im, pf, loc, sca, n);
   // Value check
-  EXPECT_TRUE(
-      MooseUtils::absoluteFuzzyEqual(loglikelihood, -502.1889, std::abs(loglikelihood / 1000)));
+  EXPECT_NEAR(loglikelihood, -502.1889, std::abs(loglikelihood / 1000));
 }
 
 // Test for maximizeLogLikelihood function in MastodonUtils

--- a/unit/src/TestMastodonUtils.C
+++ b/unit/src/TestMastodonUtils.C
@@ -3,9 +3,6 @@
 #include "MooseUtils.h"
 #include "Conversion.h"
 
-// Boost distribution includes
-#include "BoostDistribution.h"
-
 // MASTODON includes
 #include "MastodonUtils.h"
 
@@ -280,18 +277,21 @@ TEST(MastodonUtils, log10)
   }
 }
 
-// Unit tests for functions that require external BOOST
-#ifdef LIBMESH_HAVE_EXTERNAL_BOOST
 // Test for greaterProbability function in MastodonUtils
 TEST(MastodonUtils, greaterProbability)
 {
   // Inputs for testing
-  boost::math::lognormal_distribution<> demand_distribution(log(0.71), 0.39);
-  boost::math::lognormal_distribution<> capacity_distribution(log(0.71), 0.39);
+
+  Real demand_median = 0.71;
+  Real demand_scale = 0.39;
+  Real capacity_median = 0.71;
+  Real capacity_scale = 0.39;
+
   // Outputs for testing
   //  None
   // Value check
-  Real test_prob = MastodonUtils::greaterProbability(demand_distribution, capacity_distribution);
+  Real test_prob = MastodonUtils::greaterProbability(
+      demand_median, demand_scale, capacity_median, capacity_scale);
   EXPECT_TRUE(MooseUtils::absoluteFuzzyEqual(test_prob, 0.5, test_prob / 100));
 }
 
@@ -330,4 +330,3 @@ TEST(MastodonUtils, maximizeLogLikelihood)
   EXPECT_TRUE(MooseUtils::absoluteFuzzyEqual(max_values2[0], 0.3981, 1e-3));
   EXPECT_TRUE(MooseUtils::absoluteFuzzyEqual(max_values2[1], 0.2330, 1e-3));
 }
-#endif // LIBMESH_HAVE_EXTERNAL_BOOST


### PR DESCRIPTION
ref #309

I didn't create any distribution objects so I changed the interface to greaterProbability to take
the parameters needed to create the lognormal distribution.  If we want to create these distribution
objects, we will need to change the input file or create them in the fragility constructor.
greaterProbability is fixed to only deal with lognormal distributions and not general distributions which
would require an distribution object to be created.