### PR TITLE
Quick MooseDocs Edits

### DIFF
--- a/doc/content/bib/mastodon.bib
+++ b/doc/content/bib/mastodon.bib
@@ -609,14 +609,6 @@ year={2009}
   year = {2010}
 }
 
-@article{dvorkin1984continuum,
-  author = {E.~N.~Dvorkin and K.~J.~Bathe},
-  title = {A continuum mechanics based four-node shell element for general non-linear analysis},
-  journal = {Engineering Computations},
-  volume = {1},
-  pages = {77-88},
-  year ={1984}}
-
 @article{veeraraghavan2017embedded,
   author = {S.~Veeraraghavan and J.~Bielak and J.~Coleman},
   title = {Effect of inclined waves on deeply embedded nuclear facilities},

--- a/doc/content/sqa/v_and_v/materials/isoil/isoil_verification.md
+++ b/doc/content/sqa/v_and_v/materials/isoil/isoil_verification.md
@@ -1,15 +1,15 @@
 # Analytical Verification of The I-Soil Constitutive Model
 
-!include intro.md
+!include v_and_v/materials/isoil/intro.md
 
-!include problem_statement.md
+!include v_and_v/materials/isoil/problem_statement.md
 
-!include user_defined.md
+!include v_and_v/materials/isoil/user_defined.md
 
-!include darendeli.md
+!include v_and_v/materials/isoil/darendeli.md
 
-!include gqh.md
+!include v_and_v/materials/isoil/gqh.md
 
-!include pressure_dependency.md
+!include v_and_v/materials/isoil/pressure_dependency.md
 
 !bibtex bibliography


### PR DESCRIPTION
@somu15 I have two _very_ small changes I would like to merge here:

First, I deleted a redundant bibliography entry, `dvorkin1984continuum`, since the same exact entry already exists at [`idaholab/moose/tensor_mechanics/doc/content/bib/tensor_mechanics.bib`](https://github.com/idaholab/moose/blob/master/modules/tensor_mechanics/doc/content/bib/tensor_mechanics.bib), so MooseDocs issues a warning about duplicate entries. 

Second, I expanded the filenames in the `!include` calls in `isoil_verification.md` to avoid conflicts with identical filenames elsewhere in MooseDocs. Specifically, I'm working on a PR in MOOSE, idaholab/moose#15300, that creates a file named `problem_statement.md` (see the [Civet results](https://civet.inl.gov/job/575526/)). Thus, there needs to be more descriptive filenames in both MOOSE and MASTODON to be able to uniquely identify these two distinct files. It is generally good practice to be more verbose when inputting filenames into MooseDocs anyways. 

I was going to address #313 here as well, but I discovered that this issue was a false alarm for reasons I explained in a comment on that issue.

(closes #313) (refs #idaholab/moose#15300)