### PR TITLE
Another MooseDocs Edit

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -9,7 +9,10 @@ Content:
     - moose:
         root_dir: ${MOOSE_DIR}/modules/doc/content
         content:
-            - getting_started/**
+            - getting_started/installation/install_conda_moose.md
+            - getting_started/installation/install_miniconda.md
+            - getting_started/installation/uninstall_conda.md
+            - getting_started/installation/wsl.md
             - application_usage/peacock.md
             - help/development/**
             - media/**

--- a/doc/content/getting_started/mastodon_conda.md
+++ b/doc/content/getting_started/mastodon_conda.md
@@ -5,14 +5,14 @@ Application development, is via Conda's myriad array of libraries. Follow these
 instructions to create an environment on your machine using Conda. At this time,
 an option to install MOOSE directly on a Windows system is not yet supported.
 On-going efforts are being made to add a conda installation option for Windows,
-and an experimental [WSL](installation/windows10.md) option is available.
+and an experimental [WSL](getting_started/mastodon_windows10.md) option is available.
 
 
 !include sqa/minimum_requirements.md
 
 ## Prerequisites
 
-!include installation/remove_moose_environment.md
+!include getting_started/mastodon_remove_moose_environment.md
 
 !include installation/install_miniconda.md
 

--- a/doc/content/getting_started/mastodon_remove_moose_environment.md
+++ b/doc/content/getting_started/mastodon_remove_moose_environment.md
@@ -1,0 +1,20 @@
+### Transitional step for pre-existing users
+
+For those of you who have previously installed the moose-environment package, you should remove it. Removal of the moose-environment package only needs to be performed once.
+
+!alert! note title=Step not applicable to first-time users
+If you are a first time MOOSE user, please skip down to [Install Miniconda](mastodon_conda.md#installconda).
+!alert-end!
+
+- Using Conda, it is no longer necessary to have /opt/moose present on your machine. Depending on the type of machine you have, please do the following:
+
+  | Operating System | Command |
+  | :- | -: |
+  | CentOS | `sudo yum remove moose-environment` |
+  | Fedora | `sudo dnf remove moose-environment` |
+  | OpenSUSE | `sudo zypper remove moose-environment` |
+  | Debian (Ubuntu, Mint) | `sudo dpkg -r moose-environment` |
+  | Macintosh | `sudo rm -rf /opt/moose` |
+
+  !alert warning title= sudo is dangerous
+  Be especially carful with the above commands! Verify +twice+ that what you have entered in your terminal is what the instructions are asking you to do.


### PR DESCRIPTION
@cbolisetti Here's the fix for #323. I also fixed a couple other links to MOOSE website pages that were still lingering.

Ultimately, the MASTODON website looks pretty much the same, except we don't accidentally lead readers to MOOSE website pages. We also don't attempt to tokenize a bunch of pages from MOOSE's "Getting Started" that we don't need, which is a bonus.

(refs idaholab/moose#15300) (closes #323)