### PR TITLE
Make generic, the markdown file install_conda

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -16,7 +16,7 @@ Content:
         root_dir: ${MOOSE_DIR}/modules/doc/content
         content:
             - getting_started/installation/install_conda_moose.md
-            - getting_started/installation/install_miniconda.md
+            - getting_started/installation/install_conda.md
             - getting_started/installation/uninstall_conda.md
             - getting_started/installation/wsl.md
             - application_usage/peacock.md

--- a/doc/content/getting_started/mastodon_conda.md
+++ b/doc/content/getting_started/mastodon_conda.md
@@ -14,7 +14,7 @@ and an experimental [WSL](getting_started/mastodon_windows10.md) option is avail
 
 !include getting_started/mastodon_remove_moose_environment.md
 
-!include installation/install_miniconda.md
+!include installation/install_conda.md
 
 !include installation/install_conda_moose.md
 


### PR DESCRIPTION
Modify the install instructions to use the generic install_conda.md file.

DO NOT MERGE UNTIL: https://github.com/idaholab/moose/pull/19453 is merged
Obviously this will fail at first... Just creating a PR so I don't forget about it.


Closes #401
