### PR TITLE
Remove use of deprecated Elem::centroid

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -21,6 +21,7 @@ Content:
             - getting_started/installation/wsl.md
             - application_usage/peacock.md
             - help/development/**
+            - help/finite_element_concepts/nodal_patch_recovery.md
             - media/**
             - templates/**
             - bib/**

--- a/src/auxkernels/UniformLayerAuxKernel.C
+++ b/src/auxkernels/UniformLayerAuxKernel.C
@@ -55,7 +55,7 @@ UniformLayerAuxKernel::computeValue()
   if (_nodal)
     _distance = _direction * (*_current_node);
   else
-    _distance = _direction * _current_elem->centroid();
+    _distance = _direction * _current_elem->vertex_average();
 
   // Locate the layer
   std::vector<Real>::const_iterator iter =


### PR DESCRIPTION
This actually causes a data race for the `static bool did_this_already`
across threads which can lead to the occasional crash, which we've seen
on CIVET.

Closes #403

