### PR TITLE
Add template variable to mastodon_rtm.md

### DIFF
--- a/doc/content/sqa/mastodon_rtm.md
+++ b/doc/content/sqa/mastodon_rtm.md
@@ -1,1 +1,1 @@
-!template load file=app_rtm.md.template app=MASTODON category=mastodon
+!template load file=app_rtm.md.template app=MASTODON category=mastodon stp_filename=mastodon_stp.md


### PR DESCRIPTION
## Bug Description
Due to pending changes in idaholab/moose#20971, a new MooseDocs template variable is needed in all application RTM markdown files. This can be added without the MOOSE change going in, as unneeded variables will simply not be used.

## Steps to Reproduce
Build SQA documentation for mastodon using the branch in the mentioned MOOSE PR - it will fail due to lack of a template variable. 

## Impact
SQA documentation will break if the MOOSE PR is merged and the template variable is not added. 
