### PR TITLE
Documentation fixes

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -34,7 +34,6 @@ Extensions:
     MooseDocs.extensions.navigation:
         name: MASTODON
         repo: https://github.com/idaholab/mastodon
-        home: https://www.mooseframework.org/mastodon
         google-cse: 000781241768298771085:vnudcgneeya
         menu:
             Getting Started:
@@ -75,6 +74,10 @@ Extensions:
 
     MooseDocs.extensions.template:
         active: True
+
+    MooseDocs.extensions.bibtex:
+        duplicates:
+            - hales15homogenization
 
     MooseDocs.extensions.sqa:
         active: True

--- a/doc/content/documentation.menu.md
+++ b/doc/content/documentation.menu.md
@@ -21,7 +21,7 @@
 !col! small=12 medium=4 large=4
 ## Demonstration
 
-- [Examples](examples/index.md)
+- [Examples](examples/index.md exact=True)
 - [Publications](publications.md)
 
 !col-end!

--- a/doc/content/examples/example2a.md
+++ b/doc/content/examples/example2a.md
@@ -14,8 +14,8 @@ where
 
 `taumax = 7500` ; specifies maximum shear strength achieved at large shear strains.
 
-Other parameters are the same as in [Example 1](examples/index.md). Once the same boundary
-conditions are applied as in [Example 1](examples/index.md), the following response is obtained
+Other parameters are the same as in [Example 1](examples/index.md exact=True). Once the same boundary
+conditions are applied as in [Example 1](examples/index.md exact=True), the following response is obtained
 
 !media media/examples/example2stressstrain.png
        style=width:60%;margin-left:150px;float:center;

--- a/doc/content/help/faq/index.md
+++ b/doc/content/help/faq/index.md
@@ -56,7 +56,7 @@ MV2_ENABLE_AFFINITY=0 mpiexec ~/projects/mastodon/mastodon-opt -i shear_beam_Iso
 date >> out
 ```
 
-- You can re-use the above file with the following changes:    
+- You can re-use the above file with the following changes:
 
   - `FIRSTNAME.LASTNAME@inl.gov` is your INL email ID.
   - `Example03_hpc` is the name of the job.
@@ -85,7 +85,7 @@ conda activate moose
 conda update --all
 ```
 
-- You might have accidentally made some changes to MASTODON source code. To undo these changes use the below command. Then update and rebuild libmesh, compile MASTODON, and run the tests as described in the [Getting Started](getting_started/installation.md) page.  
+- You might have accidentally made some changes to MASTODON source code. To undo these changes use the below command. Then update and rebuild libmesh, compile MASTODON, and run the tests as described in the [Getting Started](getting_started/installation.md) page.
 
 ```
 git clean -dxf
@@ -97,7 +97,7 @@ Running this command will completely erase all additional files and uncommitted 
 
 ### How to write an input file from scratch?
 
-Generally, we do not recommend doing this. On the [Examples](examples/index.md) page, a variety of problems are discussed. We recommend downloading the input file from one of those problems and modifying it to suit your own problem. In this process, the MASTODON [User Manual](manuals/user/index.md) and [Syntax](syntax/index.md) pages might also help. There are also a number of input files checked into the `tests` directories within MASTODON. In addition, users are welcome to reach out to the MASTODON community through google groups and ask for files similar to what they are doing.
+Generally, we do not recommend doing this. On the [Examples](examples/index.md exact=True) page, a variety of problems are discussed. We recommend downloading the input file from one of those problems and modifying it to suit your own problem. In this process, the MASTODON [User Manual](manuals/user/index.md) and [Syntax](syntax/index.md) pages might also help. There are also a number of input files checked into the `tests` directories within MASTODON. In addition, users are welcome to reach out to the MASTODON community through google groups and ask for files similar to what they are doing.
 
 ### How to input a mesh file from ABAQUS (i.e., a `.inp` file)?
 


### PR DESCRIPTION
This PR:

- Makes links using `examples/index.md` exact so that it will not conflict with an upcoming change in idaholab/moose#22974.
- Fixes up documentation build warnings. 

Refs #3
