### PR TITLE
Add default value for vector type input parameters

### DIFF
--- a/src/actions/ISoilAction.C
+++ b/src/actions/ISoilAction.C
@@ -37,7 +37,6 @@ ISoilAction::validParams()
       "layer_variable", "The auxvariable providing the soil layer identification.");
   params.addRequiredParam<std::vector<unsigned int>>(
       "layer_ids",
-      {},
       "Vector of layer ids that map one-to-one to the rest of the "
       "soil layer parameters provided as input.");
   params.addRequiredParam<std::vector<Real>>("poissons_ratio",

--- a/src/actions/ISoilAction.C
+++ b/src/actions/ISoilAction.C
@@ -37,6 +37,7 @@ ISoilAction::validParams()
       "layer_variable", "The auxvariable providing the soil layer identification.");
   params.addRequiredParam<std::vector<unsigned int>>(
       "layer_ids",
+      {},
       "Vector of layer ids that map one-to-one to the rest of the "
       "soil layer parameters provided as input.");
   params.addRequiredParam<std::vector<Real>>("poissons_ratio",
@@ -49,6 +50,7 @@ ISoilAction::validParams()
                         "dependent stiffness for all the soil "
                         "layers.");
   params.addParam<std::vector<Real>>("p_ref",
+                                     {},
                                      "The reference pressure at which "
                                      "the parameters are defined for "
                                      "each soil layer. If 'soil_type = "
@@ -86,6 +88,7 @@ ISoilAction::validParams()
   params.addParam<bool>("implicit", true, "Set to false to use the explicit solver.");
   params.addParam<std::vector<FunctionName>>(
       "initial_soil_stress",
+      {},
       "The function values for the initial stress distribution. 9 function "
       "names have to be provided corresponding to stress_xx, stress_xy, "
       "stress_xz, stress_yx, stress_yy, stress_yz, stress_zx, stress_zy, "

--- a/src/auxkernels/UniformLayerAuxKernel.C
+++ b/src/auxkernels/UniformLayerAuxKernel.C
@@ -13,6 +13,7 @@ UniformLayerAuxKernel::validParams()
       "domain in the specified direction.");
   params.addParam<std::vector<unsigned int>>(
       "layer_ids",
+      {},
       "A list of layer identifiers to assign to each interface. "
       "If not provided integer values starting from 0 are "
       "utilized, if provided the length of this vector must be "

--- a/src/materials/ADComputeISoilStress.C
+++ b/src/materials/ADComputeISoilStress.C
@@ -53,6 +53,7 @@ ADComputeISoilStress::validParams()
                         "dependent stiffness for all the soil "
                         "layers.");
   params.addParam<std::vector<Real>>("p_ref",
+                                     {},
                                      "The reference pressure at which "
                                      "the parameters are defined for "
                                      "each soil layer. If 'soil_type = "
@@ -91,6 +92,7 @@ ADComputeISoilStress::validParams()
       "wave_speed_calculation", true, "Set to false to turn off P and S wave speed calculation.");
   params.addParam<std::vector<FunctionName>>(
       "initial_soil_stress",
+      {},
       "A list of functions describing the initial stress. There "
       "must be 9 functions, corresponding to the xx, yx, zx, xy, yy, zy, xz, yz, "
       "zz components respectively. If not provided, all components of the "

--- a/src/materials/ComputeISoilStress.C
+++ b/src/materials/ComputeISoilStress.C
@@ -48,6 +48,7 @@ ComputeISoilStress::validParams()
                         "dependent stiffness for all the soil "
                         "layers.");
   params.addParam<std::vector<Real>>("p_ref",
+                                     {},
                                      "The reference pressure at which "
                                      "the parameters are defined for "
                                      "each soil layer. If 'soil_type = "
@@ -86,6 +87,7 @@ ComputeISoilStress::validParams()
       "wave_speed_calculation", true, "Set to false to turn off P and S wave speed calculation.");
   params.addParam<std::vector<FunctionName>>(
       "initial_soil_stress",
+      {},
       "A list of functions describing the initial stress. There "
       "must be 9 functions, corresponding to the xx, yx, zx, xy, yy, zy, xz, yz, "
       "zz components respectively. If not provided, all components of the "


### PR DESCRIPTION
## Bug Description
<!--A clear and concise description of the error, failure, fault, incorrect or unexpected result, or unintended behavior (Note: A missing feature is not a bug.).-->
Refer to the issue [#24455](https://github.com/idaholab/moose/issues/24455), a fix is introduced to MOOSE to properly report error when no default value is provided for vector type input parameter. This new fix in MOOSE cause several tests failed in Mastodon which don't provide default value for vector parameter. 

## Impact
<!--Does this prevent you from getting your work done, or is it more of an annoyance?-->
This patch is made to fix the failed Mastodon tests due to the new changes in MOOSE