### PR TITLE
Added mastodon.yaml to gitignore. Addresses #439.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ doc/css/*
 *.moose.md
 *.moose.yml
 *.moose.svg
+mastodon.yaml
 site
 
 # Doxygen


### PR DESCRIPTION
Added mastodon.yaml to .gitignore. 
Closes #439 
