### PR TITLE
Remove unused (and no longer supported) import

### DIFF
--- a/data/GMSim.py
+++ b/data/GMSim.py
@@ -1,4 +1,3 @@
-from re import T
 import numpy as np
 from scipy.stats import gamma
 import sys


### PR DESCRIPTION
Remove the import line that wasn't being used anyway.
This merge will be required for Python 3.13 rollout.

Closes #462
