### PR TITLE
Update for MetaPhysicL 2

### DIFF
--- a/src/materials/ComputeIsotropicElasticityTensorSoil.C
+++ b/src/materials/ComputeIsotropicElasticityTensorSoil.C
@@ -115,7 +115,7 @@ template <bool is_ad>
 void
 ComputeIsotropicElasticityTensorSoilTempl<is_ad>::computeQpElasticityTensor()
 {
-
+  using std::sqrt, std::max;
   _P_wave_modulus = _layer_shear_modulus[_qp] * 2.0 * (1.0 - _layer_poissons_ratio[_qp]) /
                     (1.0 - 2.0 * _layer_poissons_ratio[_qp]);
 
@@ -124,10 +124,10 @@ ComputeIsotropicElasticityTensorSoilTempl<is_ad>::computeQpElasticityTensor()
   if (_wave_speed_calculation)
   {
     // Shear wave speed: sqrt(G/rho)
-    (*_shear_wave_speed)[_qp] = std::sqrt(_layer_shear_modulus[_qp] / _density[_qp]);
+    (*_shear_wave_speed)[_qp] = sqrt(_layer_shear_modulus[_qp] / _density[_qp]);
 
     // P wave speed: sqrt(M/rho)
-    (*_P_wave_speed)[_qp] = std::sqrt(_P_wave_modulus / _density[_qp]);
+    (*_P_wave_speed)[_qp] = sqrt(_P_wave_modulus / _density[_qp]);
   }
 
   std::vector<Real> iso_const(2);
@@ -140,9 +140,9 @@ ComputeIsotropicElasticityTensorSoilTempl<is_ad>::computeQpElasticityTensor()
   // Effective stiffness computations
   Real elas_mod = _layer_shear_modulus[_qp] * 2.0 * (1.0 + _layer_poissons_ratio[_qp]);
   _effective_stiffness_local =
-      std::max(std::sqrt((elas_mod * (1 - _layer_poissons_ratio[_qp])) /
-                         ((1 + _layer_poissons_ratio[_qp]) * (1 - 2 * _layer_poissons_ratio[_qp]))),
-               std::sqrt(elas_mod / (2 * (1 + _layer_poissons_ratio[_qp]))));
+      max(sqrt((elas_mod * (1 - _layer_poissons_ratio[_qp])) /
+               ((1 + _layer_poissons_ratio[_qp]) * (1 - 2 * _layer_poissons_ratio[_qp]))),
+          sqrt(elas_mod / (2 * (1 + _layer_poissons_ratio[_qp]))));
 
   // Assign elasticity tensor at a given quad point
   _elasticity_tensor[_qp] = _Cijkl;

--- a/src/meshgenerators/BeamMeshGenerator.C
+++ b/src/meshgenerators/BeamMeshGenerator.C
@@ -74,7 +74,7 @@ BeamMeshGenerator::generate()
     mooseError("BeamMeshGenerator: Mesh file should contain separate sections with node and "
                "element information.");
 
-  std::unique_ptr<ReplicatedMesh> mesh = libmesh_make_unique<ReplicatedMesh>(comm(), 2);
+  std::unique_ptr<ReplicatedMesh> mesh = std::make_unique<ReplicatedMesh>(comm(), 2);
 
   mesh->set_mesh_dimension(1);
   mesh->set_spatial_dimension(3);

--- a/src/userobjects/GroundMotionReader.C
+++ b/src/userobjects/GroundMotionReader.C
@@ -59,7 +59,7 @@ GroundMotionReader::execute(const std::string & name, const std::string & patter
   for (const std::string & filename : names)
   {
     std::unique_ptr<MooseUtils::DelimitedFileReader> reader =
-        libmesh_make_unique<MooseUtils::DelimitedFileReader>(filename);
+        std::make_unique<MooseUtils::DelimitedFileReader>(filename);
     reader->read();
     readers.emplace_back(std::move(reader));
   }


### PR DESCRIPTION
In MetaPhysicL 1.0 DualNumber overloads were put in the std namespace which is not standard compliant. This is no longer the case in MetaPhysicL 2.0; DualNumber overloads are now in the MetaPhysicL namespace, enabling Argument Dependent Lookup (ADL). We can have code both backward compatible with MetaPhysicL 1.0 and forward compatible with MetaPhysicL 2.0 leveraging the idiom used in this PR.

Refs [idaholab/moose#31906](https://github.com/idaholab/moose/pull/31906)